### PR TITLE
"_use math defines" bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ This library provides for this use case some Arduino interfaces, but not all yet
     lib_deps =
         BlueAndi/ArduinoNative @ ~0.1.0
     ```
-2. Call the ```Arduino::setup()``` once and the ```Arduino::loop()``` in a infinite loop in your main entry point function.
+2. Add this build flags to your _platformio.ini_ in your environment:
+    ```
+    build_flags =
+        -D _USE_MATH_DEFINES
+    ```
+3. Call the ```Arduino::setup()``` once and the ```Arduino::loop()``` in a infinite loop in your main entry point function.
 
 ## Example
 See [minimal example](./examples/example/).

--- a/examples/example/platformio.ini
+++ b/examples/example/platformio.ini
@@ -16,6 +16,7 @@
 platform = native @ ~1.2.1
 build_flags =
     -std=c++11
+    -D _USE_MATH_DEFINES
 lib_deps =
     MainNative
     BlueAndi/ArduinoNative @ ~0.1.1

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ArduinoNative",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Arduino for the native environment. It doesn't support every interface, just some of them!",
     "authors": [{
         "name": "Andreas Merkle",

--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -40,7 +40,9 @@
  * Compile Switches
  *****************************************************************************/
 
-#define _USE_MATH_DEFINES
+#ifndef _USE_MATH_DEFINES
+#error Please define _USE_MATH_DEFINES in your build flags.
+#endif /* _USE_MATH_DEFINES */
 
 /******************************************************************************
  * Includes
@@ -53,6 +55,9 @@
  * Macros
  *****************************************************************************/
 
+/**
+ * Constrain the given value to min. and max.
+ */
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 
 #ifndef PSTR
@@ -63,6 +68,9 @@
 #define PROGMEM
 #endif
 
+/**
+ * The constant PI.
+ */
 #define PI  M_PI
 
 /******************************************************************************


### PR DESCRIPTION
"_USE_MATH_DEFINES" must be defined at project level to ensure that its applied for the math. include. Otherwise the math. might be included already, but without "_USE_MATH_DEFINES" which will raise an error that M_PI is not defined.
